### PR TITLE
PostgreSQL running via Docker, add main admin and admin endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+POSTGRESQL_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/ai_administration
+USE_SQLITE=false
+ADMIN_EMAIL=admin@example.com
+ADMIN_FULL_NAME=Main Admin
+ADMIN_PASSWORD=admin1234
+ADMIN_FORCE_PASSWORD_UPDATE=false

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = sqlite:///./app.db
+sqlalchemy.url = postgresql+psycopg2://postgres:postgres@localhost:5432/ai_administration
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/alembic/versions/20260326_0001_create_users_table.py
+++ b/backend/alembic/versions/20260326_0001_create_users_table.py
@@ -25,7 +25,6 @@ def upgrade() -> None:
         sa.Column("email", sa.String(length=255), nullable=False),
         sa.Column("full_name", sa.String(length=255), nullable=True),
         sa.Column("hashed_password", sa.String(length=255), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)

--- a/backend/alembic/versions/20260401_0002_add_user_role.py
+++ b/backend/alembic/versions/20260401_0002_add_user_role.py
@@ -39,6 +39,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_constraint("ck_users_role", "users", type_="check")
-    op.drop_index(op.f("ix_users_role"), table_name="users")
-    op.drop_column("users", "role")
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_constraint("ck_users_role", type_="check")
+        batch_op.drop_index(op.f("ix_users_role"))
+        batch_op.drop_column("role")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -3,8 +3,17 @@ from sqlalchemy.orm import Session
 from datetime import timedelta
 
 from app.db.session import get_db
-from app.schemas.auth import UserRegister, UserLogin, Token, UserRegisterResponse
-from app.services.user_service import create_user, authenticate_user
+from app.schemas.auth import (
+    UserRegister,
+    UserLogin,
+    Token,
+    UserRegisterResponse,
+    UserRoleUpdate,
+    UserDeleteRequest,
+    UserResponse,
+    MessageResponse,
+)
+from app.services.user_service import create_user, authenticate_user, update_user_role, delete_user_by_email
 from app.core.security import create_access_token, ACCESS_TOKEN_EXPIRE_MINUTES, require_admin
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
@@ -59,3 +68,40 @@ async def login(credentials: UserLogin, db: Session = Depends(get_db)):
 @router.get("/admin/ping", dependencies=[Depends(require_admin)])
 async def admin_ping():
     return {"message": "Admin access granted"}
+
+
+@router.post("/admin/set-role", response_model=UserResponse)
+async def set_user_role(
+    role_data: UserRoleUpdate,
+    db: Session = Depends(get_db),
+    _admin=Depends(require_admin),
+):
+    user = update_user_role(db, role_data.email, role_data.role.value)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    return user
+
+
+@router.delete("/admin/remove-user", response_model=MessageResponse)
+async def remove_user(
+    user_data: UserDeleteRequest,
+    db: Session = Depends(get_db),
+    admin=Depends(require_admin),
+):
+    if user_data.email == admin.email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot delete your own admin account",
+        )
+
+    deleted = delete_user_by_email(db, user_data.email)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    return {"message": f"User {user_data.email} deleted"}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,7 +2,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    database_url: str = "sqlite:///./app.db"
+    postgresql_url: str = "postgresql+psycopg2://postgres:postgres@localhost:5432/ai_administration"
+    sqlite_url: str = "sqlite:///./app.db"
+    use_sqlite: bool = False
+
+    @property
+    def database_url(self) -> str:
+        return self.sqlite_url if self.use_sqlite else self.postgresql_url
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import DateTime, Integer, String, func, CheckConstraint
+from sqlalchemy import Integer, String, CheckConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.session import Base
@@ -14,5 +14,4 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
-    created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="user", index=True)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
 from pydantic import BaseModel, EmailStr, Field
-from datetime import datetime
 
 
 class UserRegister(BaseModel):
@@ -51,13 +50,43 @@ class UserRole(str, Enum):
     user = "user"
     admin = "admin"
 
+
+class UserRoleUpdate(BaseModel):
+    """Schema for updating a user's role"""
+    email: EmailStr
+    role: UserRole
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "email": "user@example.com",
+                "role": "admin"
+            }
+        }
+
+
+class UserDeleteRequest(BaseModel):
+    """Schema for deleting a user by email"""
+    email: EmailStr
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "email": "user@example.com"
+            }
+        }
+
+
+class MessageResponse(BaseModel):
+    """Simple message response schema"""
+    message: str
+
 class UserResponse(BaseModel):
     """Schema for user response (no password)"""
     id: int
     email: str
     full_name: str | None
     role: UserRole
-    created_at: datetime
     
     class Config:
         from_attributes = True
@@ -65,8 +94,7 @@ class UserResponse(BaseModel):
             "example": {
                 "id": 1,
                 "email": "user@example.com",
-                "full_name": "John Doe",
-                "created_at": "2026-03-27T10:30:00"
+                "full_name": "John Doe"
             }
         }
 

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -53,3 +53,26 @@ def get_user_by_email(db: Session, email: str) -> User | None:
 def get_user_by_id(db: Session, user_id: int) -> User | None:
     """Get a user by ID"""
     return db.query(User).filter(User.id == user_id).first()
+
+
+def update_user_role(db: Session, email: str, role: str) -> User | None:
+    """Update a user's role and return the updated user."""
+    user = get_user_by_email(db, email)
+    if not user:
+        return None
+
+    user.role = role
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def delete_user_by_email(db: Session, email: str) -> bool:
+    """Delete a user by email. Returns True if deleted, False if not found."""
+    user = get_user_by_email(db, email)
+    if not user:
+        return False
+
+    db.delete(user)
+    db.commit()
+    return True

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ai_administration_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ai_administration
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d ai_administration"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,10 +12,10 @@ python-multipart==0.0.9
 httpx==0.27.0
 python-dotenv==1.0.1
 matplotlib==3.7.2
-numpy==1.26.4
+numpy==2.3.0
 pandas==2.3.0
 scikit-learn==1.3.0
-scipy==1.11.4
+scipy==1.11.0
 seaborn==0.12.2
 sentence-transformers==2.2.2
 # videte za ova ne sum siguren transformers==4.30.2

--- a/backend/scripts/seed_admin.py
+++ b/backend/scripts/seed_admin.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.core.security import hash_password
+from app.db.session import SessionLocal
+from app.models.user import User
+
+
+def seed_admin(update_password: bool = False) -> None:
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_full_name = os.getenv("ADMIN_FULL_NAME", "Main Admin")
+    admin_password = os.getenv("ADMIN_PASSWORD", "admin1234")
+
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.email == admin_email).first()
+
+        if user is None:
+            user = User(
+                email=admin_email,
+                full_name=admin_full_name,
+                hashed_password=hash_password(admin_password),
+                role="admin",
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+            print(f"Created admin user: {user.email}")
+            return
+
+        changed = False
+
+        if user.role != "admin":
+            user.role = "admin"
+            changed = True
+
+        if update_password:
+            user.hashed_password = hash_password(admin_password)
+            changed = True
+
+        if changed:
+            db.commit()
+            db.refresh(user)
+            print(f"Updated admin user: {user.email}")
+        else:
+            print(f"Admin user already present: {user.email}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    force_password_update = os.getenv("ADMIN_FORCE_PASSWORD_UPDATE", "false").lower() == "true"
+    seed_admin(update_password=force_password_update)


### PR DESCRIPTION
Database switched to PostgreSQL and created Docker container. 
Added main Admin, to log in:
user: admin@example.com
pass: admin1234
Admin can now change users' roles (from basic user to admin and vice versa) and delete users from database. 

COMPLETE SET-UP GUIDE:
Make sure you have Docker Desktop and PostgreSQL installed on your PC. 

1. go to root of \backend folder in terminal
2. run: .\venv\Scripts\activate
3. install dependencies (if not done yet): pip install -r requirements.txt
4. run Docker Desktop and run this in terminal: docker compose up -d postgres
5. apply DB schemas - run: python -m alembic upgrade head
6. create the main admin: python scripts/seed_admin.py (the admin will persist unless you wipe docker data with docker down -v)
7. start the app/api: python -m uvicorn app.main:app --reload (and go to http://127.0.0.1:8000/docs)
8. when done coding: docker compose down (to stop docker container, this will not wipe data)

Steps 3, 5 and 6 should only be done once, during the initial setup and/or after every change to "requirements.txt", "alembic files" and the "seed_admin.py" file.
Use steps 1, 2, 4 and 7 for every session 