### PR TITLE
Add location services endpoint with model, migration and seed data

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/AI_Administration_Team_17.iml
+++ b/.idea/AI_Administration_Team_17.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.12" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/AI_Administration_Team_17.iml" filepath="$PROJECT_DIR$/.idea/AI_Administration_Team_17.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/backend/alembic/versions/20260407_0003_create_service_office_table.py
+++ b/backend/alembic/versions/20260407_0003_create_service_office_table.py
@@ -1,0 +1,43 @@
+"""create service_offices table
+
+Revision ID: 20260407_0003
+Revises:
+Create Date: 2026-04-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260407_0003"
+down_revision: Union[str, None] = "20260401_0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "service_offices",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("service_name", sa.String(length=255), nullable=False),
+        sa.Column("service_id", sa.String(length=100), nullable=False),
+        sa.Column("office_name", sa.String(length=255), nullable=False),
+        sa.Column("address", sa.String(length=500), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=False),
+        sa.Column("longitude", sa.Float(), nullable=False),
+        sa.Column("working_hours", sa.String(length=255), nullable=False),
+        sa.Column("contact_email", sa.String(length=255), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("service_id"),
+    )
+    op.create_index("ix_service_offices_id", "service_offices", ["id"])
+    op.create_index("ix_service_offices_service_name", "service_offices", ["service_name"])
+    op.create_index("ix_service_offices_service_id", "service_offices", ["service_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_service_offices_service_id", table_name="service_offices")
+    op.drop_index("ix_service_offices_service_name", table_name="service_offices")
+    op.drop_index("ix_service_offices_id", table_name="service_offices")
+    op.drop_table("service_offices")

--- a/backend/app/api/location.py
+++ b/backend/app/api/location.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import or_, func
+
+from app.db.session import get_db
+from app.models.service_office import ServiceOffice
+from app.schemas.service_office import ServiceOfficeResponse, CoordinatesSchema
+
+router = APIRouter(prefix="/location", tags=["Location Services"])
+
+
+def _to_response(office: ServiceOffice) -> ServiceOfficeResponse:
+    return ServiceOfficeResponse(
+        service_id=office.service_id,
+        service_name=office.service_name,
+        office_name=office.office_name,
+        address=office.address,
+        coordinates=CoordinatesSchema(lat=office.latitude, lng=office.longitude),
+        working_hours=office.working_hours,
+        contact_email=office.contact_email,
+        notes=office.notes,
+    )
+
+
+@router.get(
+    "/service",
+    response_model=ServiceOfficeResponse,
+    summary="Get office location for a government service",
+    description=(
+        "Returns office details (name, address, coordinates, working hours, contact email) "
+        "for a given service. Accepts either a human-readable service name or a service ID."
+    ),
+)
+def get_service_location(
+    service: str = Query(
+        ...,
+        description="Service name (e.g. 'Passport Renewal') or service ID (e.g. 'passport-renewal')",
+        min_length=1,
+    ),
+    db: Session = Depends(get_db),
+) -> ServiceOfficeResponse:
+    """
+    Lookup a government service office by name or ID.
+
+    - **service**: case-insensitive service name OR exact service_id
+    """
+    office = (
+        db.query(ServiceOffice)
+        .filter(
+            or_(
+                func.lower(ServiceOffice.service_name) == service.strip().lower(),
+                ServiceOffice.service_id == service.strip().lower(),
+            )
+        )
+        .first()
+    )
+
+    if not office:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No office found for service '{service}'. "
+                   "Please check the service name or ID and try again.",
+        )
+
+    return _to_response(office)
+
+
+@router.get(
+    "/services",
+    response_model=list[ServiceOfficeResponse],
+    summary="List all available government service offices",
+    description="Returns a paginated list of all registered service offices.",
+)
+def list_service_locations(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    db: Session = Depends(get_db),
+) -> list[ServiceOfficeResponse]:
+    offices = db.query(ServiceOffice).offset(skip).limit(limit).all()
+    return [_to_response(o) for o in offices]

--- a/backend/app/api/location.py
+++ b/backend/app/api/location.py
@@ -4,13 +4,19 @@ from sqlalchemy import or_, func
 
 from app.db.session import get_db
 from app.models.service_office import ServiceOffice
-from app.schemas.service_office import ServiceOfficeResponse, CoordinatesSchema
+from app.schemas.service_office import (
+    ServiceOfficeResponse,
+    ServiceOfficeCreate,
+    ServiceOfficeUpdate,
+    CoordinatesSchema,
+)
 
 router = APIRouter(prefix="/location", tags=["Location Services"])
 
 
 def _to_response(office: ServiceOffice) -> ServiceOfficeResponse:
     return ServiceOfficeResponse(
+        id=office.id,
         service_id=office.service_id,
         service_name=office.service_name,
         office_name=office.office_name,
@@ -22,28 +28,50 @@ def _to_response(office: ServiceOffice) -> ServiceOfficeResponse:
     )
 
 
+# GET all
+
+@router.get(
+    "/services",
+    response_model=list[ServiceOfficeResponse],
+    summary="Get all service office locations",
+)
+def list_service_locations(
+        skip: int = Query(0, ge=0),
+        limit: int = Query(50, ge=1, le=200),
+        db: Session = Depends(get_db),
+) -> list[ServiceOfficeResponse]:
+    offices = db.query(ServiceOffice).offset(skip).limit(limit).all()
+    return [_to_response(o) for o in offices]
+
+
+# Get single by ID
+
+@router.get(
+    "/services/{location_id}",
+    response_model=ServiceOfficeResponse,
+    summary="Get a single service office by ID",
+)
+def get_service_location_by_id(
+        location_id: int,
+        db: Session = Depends(get_db),
+) -> ServiceOfficeResponse:
+    office = db.query(ServiceOffice).filter(ServiceOffice.id == location_id).first()
+    if not office:
+        raise HTTPException(status_code=404, detail=f"Location with id {location_id} not found.")
+    return _to_response(office)
+
+
+# Get by service name or service ID
+
 @router.get(
     "/service",
     response_model=ServiceOfficeResponse,
-    summary="Get office location for a government service",
-    description=(
-        "Returns office details (name, address, coordinates, working hours, contact email) "
-        "for a given service. Accepts either a human-readable service name or a service ID."
-    ),
+    summary="Get office location by service name or service ID",
 )
 def get_service_location(
-    service: str = Query(
-        ...,
-        description="Service name (e.g. 'Passport Renewal') or service ID (e.g. 'passport-renewal')",
-        min_length=1,
-    ),
-    db: Session = Depends(get_db),
+        service: str = Query(..., min_length=1, description="Service name or service_id"),
+        db: Session = Depends(get_db),
 ) -> ServiceOfficeResponse:
-    """
-    Lookup a government service office by name or ID.
-
-    - **service**: case-insensitive service name OR exact service_id
-    """
     office = (
         db.query(ServiceOffice)
         .filter(
@@ -54,27 +82,102 @@ def get_service_location(
         )
         .first()
     )
-
     if not office:
         raise HTTPException(
             status_code=404,
-            detail=f"No office found for service '{service}'. "
-                   "Please check the service name or ID and try again.",
+            detail=f"No office found for service '{service}'.",
         )
-
     return _to_response(office)
 
 
-@router.get(
+# Post create
+
+@router.post(
     "/services",
-    response_model=list[ServiceOfficeResponse],
-    summary="List all available government service offices",
-    description="Returns a paginated list of all registered service offices.",
+    response_model=ServiceOfficeResponse,
+    status_code=201,
+    summary="Create a new service office location",
 )
-def list_service_locations(
-    skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
-    db: Session = Depends(get_db),
-) -> list[ServiceOfficeResponse]:
-    offices = db.query(ServiceOffice).offset(skip).limit(limit).all()
-    return [_to_response(o) for o in offices]
+def create_service_location(
+        payload: ServiceOfficeCreate,
+        db: Session = Depends(get_db),
+) -> ServiceOfficeResponse:
+    existing = db.query(ServiceOffice).filter(
+        ServiceOffice.service_id == payload.service_id
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A location with service_id '{payload.service_id}' already exists.",
+        )
+
+    office = ServiceOffice(
+        service_id=payload.service_id,
+        service_name=payload.service_name,
+        office_name=payload.office_name,
+        address=payload.address,
+        latitude=payload.coordinates.lat,
+        longitude=payload.coordinates.lng,
+        working_hours=payload.working_hours,
+        contact_email=payload.contact_email,
+        notes=payload.notes,
+    )
+    db.add(office)
+    db.commit()
+    db.refresh(office)
+    return _to_response(office)
+
+
+# Put update
+
+@router.put(
+    "/services/{location_id}",
+    response_model=ServiceOfficeResponse,
+    summary="Update an existing service office location",
+)
+def update_service_location(
+        location_id: int,
+        payload: ServiceOfficeUpdate,
+        db: Session = Depends(get_db),
+) -> ServiceOfficeResponse:
+    office = db.query(ServiceOffice).filter(ServiceOffice.id == location_id).first()
+    if not office:
+        raise HTTPException(status_code=404, detail=f"Location with id {location_id} not found.")
+
+    if payload.service_name is not None:
+        office.service_name = payload.service_name
+    if payload.office_name is not None:
+        office.office_name = payload.office_name
+    if payload.address is not None:
+        office.address = payload.address
+    if payload.coordinates is not None:
+        office.latitude = payload.coordinates.lat
+        office.longitude = payload.coordinates.lng
+    if payload.working_hours is not None:
+        office.working_hours = payload.working_hours
+    if payload.contact_email is not None:
+        office.contact_email = payload.contact_email
+    if payload.notes is not None:
+        office.notes = payload.notes
+
+    db.commit()
+    db.refresh(office)
+    return _to_response(office)
+
+
+# Delete
+
+@router.delete(
+    "/services/{location_id}",
+    status_code=204,
+    summary="Delete a service office location",
+)
+def delete_service_location(
+        location_id: int,
+        db: Session = Depends(get_db),
+) -> None:
+    office = db.query(ServiceOffice).filter(ServiceOffice.id == location_id).first()
+    if not office:
+        raise HTTPException(status_code=404, detail=f"Location with id {location_id} not found.")
+    db.delete(office)
+    db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,11 +20,8 @@ app.add_middleware(
 # Include routers
 app.include_router(auth_router)
 app.include_router(chat_router)
-<<<<<<< HEAD
 app.include_router(services_router)
-=======
 app.include_router(location_router)
->>>>>>> 05a4d9d (Add location services endpoint with model, migration and seed data)
 
 @app.get("/")
 async def read_root():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.auth import router as auth_router
 from app.api.chat import router as chat_router
 from app.api.services import router as services_router
+from app.api.location import router as location_router
 
 app = FastAPI(title="AI Public Administration API", version="1.0.0")
 
@@ -19,7 +20,11 @@ app.add_middleware(
 # Include routers
 app.include_router(auth_router)
 app.include_router(chat_router)
+<<<<<<< HEAD
 app.include_router(services_router)
+=======
+app.include_router(location_router)
+>>>>>>> 05a4d9d (Add location services endpoint with model, migration and seed data)
 
 @app.get("/")
 async def read_root():

--- a/backend/app/models/service_office.py
+++ b/backend/app/models/service_office.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, Float, Text
+from app.db.session import Base
+
+
+class ServiceOffice(Base):
+    __tablename__ = "service_offices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    service_name = Column(String(255), nullable=False, index=True)
+    service_id = Column(String(100), unique=True, nullable=False, index=True)
+    office_name = Column(String(255), nullable=False)
+    address = Column(String(500), nullable=False)
+    latitude = Column(Float, nullable=False)
+    longitude = Column(Float, nullable=False)
+    working_hours = Column(String(255), nullable=False)
+    contact_email = Column(String(255), nullable=False)
+    notes = Column(Text, nullable=True)

--- a/backend/app/schemas/service_office.py
+++ b/backend/app/schemas/service_office.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class CoordinatesSchema(BaseModel):
+    lat: float
+    lng: float
+
+
+class ServiceOfficeResponse(BaseModel):
+    service_id: str
+    service_name: str
+    office_name: str
+    address: str
+    coordinates: CoordinatesSchema
+    working_hours: str
+    contact_email: str
+    notes: Optional[str] = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/service_office.py
+++ b/backend/app/schemas/service_office.py
@@ -7,7 +7,29 @@ class CoordinatesSchema(BaseModel):
     lng: float
 
 
+class ServiceOfficeCreate(BaseModel):
+    service_id: str
+    service_name: str
+    office_name: str
+    address: str
+    coordinates: CoordinatesSchema
+    working_hours: str
+    contact_email: str
+    notes: Optional[str] = None
+
+
+class ServiceOfficeUpdate(BaseModel):
+    service_name: Optional[str] = None
+    office_name: Optional[str] = None
+    address: Optional[str] = None
+    coordinates: Optional[CoordinatesSchema] = None
+    working_hours: Optional[str] = None
+    contact_email: Optional[str] = None
+    notes: Optional[str] = None
+
+
 class ServiceOfficeResponse(BaseModel):
+    id: int
     service_id: str
     service_name: str
     office_name: str

--- a/backend/scripts/seed_service_offices.py
+++ b/backend/scripts/seed_service_offices.py
@@ -1,0 +1,128 @@
+"""
+Seed the service_offices table with realistic Macedonian government service data.
+
+Usage:
+    python seed_service_offices.py
+"""
+import os
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.db.session import SessionLocal
+from app.models.service_office import ServiceOffice
+
+OFFICES = [
+    {
+        "service_id": "passport-renewal",
+        "service_name": "Passport Renewal",
+        "office_name": "Ministry of Interior – Passport Department",
+        "address": "Dimitar Vlahov bb, 1000 Skopje",
+        "latitude": 41.9981,
+        "longitude": 21.4254,
+        "working_hours": "Mon–Fri 08:00–16:00",
+        "contact_email": "pasosи@mvr.gov.mk",
+        "notes": "Appointments strongly recommended. Bring two passport photos and a valid ID.",
+    },
+    {
+        "service_id": "birth-certificate",
+        "service_name": "Birth Certificate",
+        "office_name": "Municipality of Centar – Registry Office",
+        "address": "Bulevar Partizanski Odredi 42, 1000 Skopje",
+        "latitude": 41.9944,
+        "longitude": 21.4314,
+        "working_hours": "Mon–Fri 08:30–15:30",
+        "contact_email": "maticna@centar.gov.mk",
+        "notes": "Original hospital birth record required for first-time registration.",
+    },
+    {
+        "service_id": "vehicle-registration",
+        "service_name": "Vehicle Registration",
+        "office_name": "Ministry of Interior – Vehicle Registration Center",
+        "address": "Orce Nikolov 177, 1000 Skopje",
+        "latitude": 42.0058,
+        "longitude": 21.4089,
+        "working_hours": "Mon–Fri 07:30–15:00",
+        "contact_email": "registracija@mvr.gov.mk",
+        "notes": "Payment of road tax must be completed before visiting. ZOUK insurance required.",
+    },
+    {
+        "service_id": "tax-filing",
+        "service_name": "Tax Filing",
+        "office_name": "Public Revenue Office – Skopje Regional Center",
+        "address": "Dame Gruev 14, 1000 Skopje",
+        "latitude": 41.9965,
+        "longitude": 21.4342,
+        "working_hours": "Mon–Fri 08:00–16:00",
+        "contact_email": "contact@ujp.gov.mk",
+        "notes": "Online filing available at e-ujp.ujp.gov.mk. Office visits for complex cases only.",
+    },
+    {
+        "service_id": "unemployment-benefit",
+        "service_name": "Unemployment Benefit",
+        "office_name": "Employment Service Agency – Skopje Center",
+        "address": "Jane Sandanski 39, 1000 Skopje",
+        "latitude": 41.9901,
+        "longitude": 21.4406,
+        "working_hours": "Mon–Fri 08:00–16:00",
+        "contact_email": "info@avrm.gov.mk",
+        "notes": "Bring proof of previous employment and a valid ID. Register within 30 days of termination.",
+    },
+    {
+        "service_id": "health-insurance-card",
+        "service_name": "Health Insurance Card",
+        "office_name": "Health Insurance Fund – Skopje Regional Office",
+        "address": "Makedonija 12, 1000 Skopje",
+        "latitude": 41.9959,
+        "longitude": 21.4318,
+        "working_hours": "Mon–Fri 08:30–16:00",
+        "contact_email": "fond@fzo.org.mk",
+        "notes": "Proof of active employment or pension is required. Processing takes up to 5 business days.",
+    },
+    {
+        "service_id": "land-registry",
+        "service_name": "Land Registry",
+        "office_name": "Agency for Real Estate Cadastre – Skopje",
+        "address": "Gjuro Gjakovikj 5, 1000 Skopje",
+        "latitude": 41.9971,
+        "longitude": 21.4197,
+        "working_hours": "Mon–Fri 08:00–17:00",
+        "contact_email": "skopje@katastar.gov.mk",
+        "notes": "Property ownership certificates can also be obtained via e-katastar portal.",
+    },
+    {
+        "service_id": "business-registration",
+        "service_name": "Business Registration",
+        "office_name": "Central Registry of North Macedonia",
+        "address": "Sv. Kliment Ohridski 4, 1000 Skopje",
+        "latitude": 41.9935,
+        "longitude": 21.4350,
+        "working_hours": "Mon–Fri 08:00–16:00",
+        "contact_email": "contact@crm.org.mk",
+        "notes": "New companies can be registered online via e-registracija.crm.org.mk in under 4 hours.",
+    },
+]
+
+
+def seed() -> None:
+    db = SessionLocal()
+    try:
+        existing_ids = {row.service_id for row in db.query(ServiceOffice.service_id).all()}
+        new_offices = [
+            ServiceOffice(**data) for data in OFFICES if data["service_id"] not in existing_ids
+        ]
+        if new_offices:
+            db.add_all(new_offices)
+            db.commit()
+            print(f"Seeded {len(new_offices)} service office(s).")
+        else:
+            print("All service offices already present – nothing to seed.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
Implements the location services endpoint for the frontend map pin feature.

What's included:
- GET /location/service?service= — lookup by service name or ID
- GET /location/services — list all available offices
- ServiceOffice model, migration and schema
- Seeded 8 Macedonian government service offices with real coordinates

Response includes office name, address, lat/lng coordinates, working hours 
and contact email — ready for the frontend to use as map pins.

To set up locally:
1. python -m alembic upgrade head
2. python scripts/seed_service_offices.py